### PR TITLE
Artifact deployment to s3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,4 @@ build:
 	gucumber
 	cd cmd
 	go build -o atompub
-	cp atompub /artifacts
+	cp atompub /buildhome

--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,4 @@ build:
 	gucumber
 	cd cmd
 	go build -o atompub
-	docker build -t xtracdev/atompub .
+    cp atompub /artifacts

--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,6 @@ build:
 	go get golang.org/x/tools/blog/atom
 	go test
 	gucumber
+	cd cmd
+	go build -o atompub
+	docker build -t xtracdev/atompub .

--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,4 @@ build:
 	gucumber
 	cd cmd
 	go build -o atompub
-    cp atompub /artifacts
+	cp atompub /artifacts

--- a/circle.yml
+++ b/circle.yml
@@ -15,6 +15,7 @@ deployment:
     branch: docker-image-build
     commands:
       - cd cmd
+      - ls
       - cp Dockerfile ../
       - cd ..
       - ls

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
 
 dependencies:
   override:
-    - docker run --rm -v "$PWD":/go/src/github.com/xtracdev/es-atom-pub -e DB_USER=$DB_USER -e DB_PASSWORD=$DB_PASSWORD -e DB_HOST=$DB_HOST -e DB_PORT=$DB_PORT -e DB_SVC=$DB_SVC -w /go/src/github.com/xtracdev/es-atom-pub xtracdev/goora bash -c make
+    - docker run --rm -v "$PWD":/go/src/github.com/xtracdev/es-atom-pub -v "$CIRCLE_ARTIFACTS":/artifacts -e DB_USER=$DB_USER -e DB_PASSWORD=$DB_PASSWORD -e DB_HOST=$DB_HOST -e DB_PORT=$DB_PORT -e DB_SVC=$DB_SVC -w /go/src/github.com/xtracdev/es-atom-pub xtracdev/goora bash -c make
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -12,6 +12,7 @@ test:
 
 deployment:
   hub:
+    branch: master
     commands:
       - cd cmd
       - cp $CIRCLE_ARTIFACTS/atompub .

--- a/circle.yml
+++ b/circle.yml
@@ -15,4 +15,4 @@ deployment:
     branch: docker-image-build
     commands:
       - ls
-      - aws s3 cp atompub s3://xt-circle-ci/es-atom-pub
+      - aws s3 cp atompub s3://xt-circle-ci/es-atom-pub/atompub

--- a/circle.yml
+++ b/circle.yml
@@ -9,3 +9,11 @@ dependencies:
 test:
   override:
     - echo 'test automation run as part of the docker build'
+
+deployment:
+  hub:
+    - cd cmd
+    - cp $CIRCLE_ARTIFACTS/atompub .
+    - docker build -t xtracdev/atompub .
+    - docker login -u $DOCKER_USER -p $DOCKER_PASS
+    - docker push xtracdev/atompub

--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,7 @@ test:
 
 deployment:
   hub:
-    branch: master
+    branch: docker-image-build
     commands:
       - cd cmd
       - cp $CIRCLE_ARTIFACTS/atompub .

--- a/circle.yml
+++ b/circle.yml
@@ -16,6 +16,7 @@ deployment:
     commands:
       - cp ./cmd/Dockerfile .
       - ls
+      - docker version
       - docker build -t xtracdev/atompub .
       - docker login -u $DOCKER_USER -p $DOCKER_PASS
       - docker push xtracdev/atompub

--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,7 @@ test:
 
 deployment:
   hub:
-    branch: docker-image-build
+    branch: master
     commands:
       - ls
       - aws s3 cp atompub s3://xt-circle-ci/es-atom-pub/atompub

--- a/circle.yml
+++ b/circle.yml
@@ -15,7 +15,9 @@ deployment:
     branch: docker-image-build
     commands:
       - cd cmd
-      - cp $HOME/atompub .
+      - cp Dockerfile ../
+      - cd ..
+      - ls
       - docker build -t xtracdev/atompub .
       - docker login -u $DOCKER_USER -p $DOCKER_PASS
       - docker push xtracdev/atompub

--- a/circle.yml
+++ b/circle.yml
@@ -12,8 +12,9 @@ test:
 
 deployment:
   hub:
-    - cd cmd
-    - cp $CIRCLE_ARTIFACTS/atompub .
-    - docker build -t xtracdev/atompub .
-    - docker login -u $DOCKER_USER -p $DOCKER_PASS
-    - docker push xtracdev/atompub
+    commands:
+      - cd cmd
+      - cp $CIRCLE_ARTIFACTS/atompub .
+      - docker build -t xtracdev/atompub .
+      - docker login -u $DOCKER_USER -p $DOCKER_PASS
+      - docker push xtracdev/atompub

--- a/circle.yml
+++ b/circle.yml
@@ -14,9 +14,5 @@ deployment:
   hub:
     branch: docker-image-build
     commands:
-      - cp ./cmd/Dockerfile .
       - ls
-      - docker version
-      - docker build -t xtracdev/atompub .
-      - docker login -u $DOCKER_USER -p $DOCKER_PASS
-      - docker push xtracdev/atompub
+      - aws s3 cp atompub s3://xt-circle-ci/es-atom-pub

--- a/circle.yml
+++ b/circle.yml
@@ -14,10 +14,7 @@ deployment:
   hub:
     branch: docker-image-build
     commands:
-      - cd cmd
-      - ls
-      - cp Dockerfile ../
-      - cd ..
+      - cp ./cmd/Dockerfile .
       - ls
       - docker build -t xtracdev/atompub .
       - docker login -u $DOCKER_USER -p $DOCKER_PASS

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
 
 dependencies:
   override:
-    - docker run --rm -v "$PWD":/go/src/github.com/xtracdev/es-atom-pub -v "$CIRCLE_ARTIFACTS":/artifacts -e DB_USER=$DB_USER -e DB_PASSWORD=$DB_PASSWORD -e DB_HOST=$DB_HOST -e DB_PORT=$DB_PORT -e DB_SVC=$DB_SVC -w /go/src/github.com/xtracdev/es-atom-pub xtracdev/goora bash -c make
+    - docker run --rm -v "$PWD":/go/src/github.com/xtracdev/es-atom-pub -v $HOME:/buildhome -e DB_USER=$DB_USER -e DB_PASSWORD=$DB_PASSWORD -e DB_HOST=$DB_HOST -e DB_PORT=$DB_PORT -e DB_SVC=$DB_SVC -w /go/src/github.com/xtracdev/es-atom-pub xtracdev/goora bash -c make
 
 test:
   override:
@@ -15,7 +15,7 @@ deployment:
     branch: docker-image-build
     commands:
       - cd cmd
-      - cp $CIRCLE_ARTIFACTS/atompub .
+      - cp $HOME/atompub .
       - docker build -t xtracdev/atompub .
       - docker login -u $DOCKER_USER -p $DOCKER_PASS
       - docker push xtracdev/atompub


### PR DESCRIPTION
Updates to deploy built binary to s3. Circle CI does not support the docker 1.12.x version which is needed to build images with a health check.